### PR TITLE
Small UI changes (plus Todo Tagger)

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -107,6 +107,10 @@ onBeforeMount(async () => {
     }
   });
 
+  EventBus.$on('add-font-panel', addFontPanel);
+  EventBus.$on('remove-tag', removeTag);
+  EventBus.$on('update:tags', updateTags);
+
   appLoaded.value = true;
 
 });
@@ -129,8 +133,7 @@ onBeforeMount(async () => {
       <div style="display: flex; flex-direction: row; width: 100vw; min-height: 100vh;">
         <div v-for="(panel, idx) in panels" :key="idx"
           :style="{ flex: '1 1 0', minWidth: 0, borderRight: idx < panels.length - 1 ? '1px solid #eee' : 'none', height: '100vh', overflow: 'auto' }">
-          <panel :panel="panel" :gf="gf" :tags="tags?.items || []" @remove-panel="removePanel(idx)"
-            @add-font-panel="addFontPanel" @update-tags="updateTags" @remove-tag="removeTag">
+          <panel :panel="panel" :gf="gf" :tags="tags?.items || []" @remove-panel="removePanel(idx)">
           </panel>
         </div>
       </div>

--- a/src/App.vue
+++ b/src/App.vue
@@ -62,6 +62,9 @@ function performAddCategory(category: string) {
 function addFontPanel(font: string) {
   panels.value.push({ type: 'font', font });
 }
+function addTodoPanel() {
+  panels.value.push({ type: 'todo' });
+}
 function addCategoriesPanel(categories: string[]) {
   panels.value.push({
     type: 'categories', categories, tagGroups: tagGroups.value
@@ -124,6 +127,7 @@ onBeforeMount(async () => {
     <div id="content" v-if="appLoaded">
       <button @click="addFontPanel('Maven Pro')">Tags in font</button>
       <button @click="addCategoriesPanel(['/Expressive/Loud'])">Tags in category</button>
+      <button @click="addTodoPanel()">Todo List</button>
       <add-tag :categories="categories" @tag-added="performAddTag"></add-tag>
       <add-tags :categories="categories" @tags-added="performAddTags"></add-tags>
       <add-category @category-added="performAddCategory"></add-category>

--- a/src/App.vue
+++ b/src/App.vue
@@ -101,10 +101,7 @@ onBeforeMount(async () => {
   }
 
   EventBus.$on('ensure-loaded', (family: string) => {
-    const font = gf.value?.families.find(f => f.name === family);
-    if (family && !gf.value?.loadedFamilies.includes(font!)) {
-      gf.value?.loadedFamilies.push(font!);
-    }
+    gf.value?.ensureLoaded(family);
   });
 
   EventBus.$on('add-font-panel', addFontPanel);

--- a/src/App.vue
+++ b/src/App.vue
@@ -130,7 +130,7 @@ onBeforeMount(async () => {
       <div style="display: flex; flex-direction: row; width: 100vw; min-height: 100vh;">
         <div v-for="(panel, idx) in panels" :key="idx"
           :style="{ flex: '1 1 0', minWidth: 0, borderRight: idx < panels.length - 1 ? '1px solid #eee' : 'none', height: '100vh', overflow: 'auto' }">
-          <panel :panel="panel" :gf="gf" :tags="tags?.items || []" @remove-panel="removePanel(idx)">
+          <panel :panel="panel" :gf="gf" :tags="tags" @remove-panel="removePanel(idx)">
           </panel>
         </div>
       </div>

--- a/src/assets/main.css
+++ b/src/assets/main.css
@@ -11,7 +11,7 @@ h1,h2,h3 { margin-top: 0; margin-bottom: 0; }
 .tag-info { color: #007ac0; }
 
 .tag-view { padding: 5px; border: 1px solid #eee; margin-bottom: 10px; }
-.tag-name { display: inline-block; width: 200px; font-family: monospace; font-weight: bold; }
+.tag-name { display: inline-block; min-width: 200px; font-family: monospace; font-weight: bold; }
 .tag-family { width: 200px; display: inline-block; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
 .tag-score { padding-left: 20px; color: #888; }
 
@@ -19,3 +19,102 @@ h1,h2,h3 { margin-top: 0; margin-bottom: 0; }
 .panel { margin: 5px; padding: 5px; }
 
 .sample { font-size: 25pt; text-overflow: ellipsis; white-space: nowrap; overflow: hidden; width: 100%; margin-top: 5px; margin-bottom: 5px; }
+.compact-tag-view {
+    display: flex;
+    flex-direction: row;
+    align-items: baseline;
+}
+.compact-tag-view .tag-title .tag-score {
+    margin-right: 10px;
+    width: 30px;
+}
+
+.compact-tag-view .tag-title {
+    display: flex;
+}
+.compact-tag-view .text {
+    display: flex;
+    padding: 5px;
+}
+.compact-tag-view .tag-family {
+    width: inherit;
+}
+
+.exemplars {
+    display: flex;
+    flex-direction: row;
+    margin-top: 5px;
+    justify-content: space-between;
+    flex-wrap: wrap;
+
+}
+.exemplars > div {
+    background-color: #fafafa;
+    padding: 15px;
+    min-width: 120px;
+}
+
+.progressbar {
+  background-color: black;
+  border-radius: 13px;
+  padding: 3px;
+  height: 20px;
+}
+.progressbar .progress-text {
+  color: white;
+  text-align: center;
+  font-size: 14px;
+  margin-top: -20px; /* Adjust based on height of progress bar */
+}
+
+.progressbar .progress {
+  background-color: orange;
+  height: 20px;
+  border-radius: 10px;
+}
+#todo-wrapper h1, #todo-wrapper h3 { text-align: center;}
+
+.rangeslider {
+    width: 100%;
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: space-between;
+}
+.rangeslider span {
+    position: relative;
+    margin: 15px -4px 0 0px;
+    flex-basis: 0;
+    flex-grow: 0;
+    text-align: center;
+    font-size: 0.85em;
+    user-select: none;
+}
+.rangeslider span:first-of-type {
+    margin-left: 15px;
+    margin-right: 0px;
+}
+.rangeslider span:last-of-type {
+    margin-right: 7px;
+
+}
+.rangeslider span::after {
+    content: "";
+    position: absolute;
+    width: 1px;
+    height: 8px;
+    left: 0;
+    right: 0;
+    margin: auto;
+    top: -12px;
+    background-color: #ccc;
+}
+.rangeslider input {
+    width: 100%;
+    margin: 5px 10px;
+    position: relative;
+    background-color: #ccc;
+    border-radius: 99px;
+    z-index: 10;
+    height: 7px;
+    -webkit-appearance: none;
+}

--- a/src/components/CompactTagView.vue
+++ b/src/components/CompactTagView.vue
@@ -1,0 +1,28 @@
+<script setup lang="ts">
+import { defineProps, onBeforeMount } from 'vue';
+import { FontTag } from '../models';
+import { EventBus } from '@/eventbus';
+
+const props = defineProps({
+    tag: FontTag,
+});
+
+onBeforeMount(() => {
+    EventBus.$emit('ensure-loaded', props.tag?.family.name);
+});
+</script>
+
+
+<template>
+    <div class="compact-tag-view">
+        <div class="tag-title">
+            <span class="tag-score" v-if="props.tag">
+                {{ props.tag.score }}
+            </span>
+            <span class="tag-family">{{ props.tag?.family.name }}</span>
+        </div>
+        <div class="text" contenteditable="true" :style="props.tag?.cssStyle(18)">
+            Hello world
+        </div>
+    </div>
+</template>

--- a/src/components/Panel.vue
+++ b/src/components/Panel.vue
@@ -45,8 +45,8 @@ onMounted(() => {
 <template>
   <div class="panel" style="border:1px solid #ccc; padding:1em; margin-bottom:1em;">
     <button @click="emit('remove-panel')" style="float:right">✕</button>
-    <tags-by-font v-if="panel.type === 'font'" :tags="tags" :font="panel.font" :gf="gf"></tags-by-font>
-    <tags-by-categories v-else-if="panel.type === 'categories'" :tags="tags" :categories="panel.categories"
+    <tags-by-font v-if="panel.type === 'font'" :tags="tags.items" :font="panel.font" :gf="gf"></tags-by-font>
+    <tags-by-categories v-else-if="panel.type === 'categories'" :tags="tags.items" :categories="panel.categories"
       :tagGroups="panel.tagGroups" :gf="gf"></tags-by-categories>
   </div>
 </template>

--- a/src/components/Panel.vue
+++ b/src/components/Panel.vue
@@ -47,6 +47,6 @@ onMounted(() => {
     <button @click="emit('remove-panel')" style="float:right">✕</button>
     <tags-by-font v-if="panel.type === 'font'" :tags="tags" :font="panel.font" :gf="gf"></tags-by-font>
     <tags-by-categories v-else-if="panel.type === 'categories'" :tags="tags" :categories="panel.categories"
-      :tagGroups="panel.tagGroups" :gf="gf" @remove-tag="removeTag"></tags-by-categories>
+      :tagGroups="panel.tagGroups" :gf="gf"></tags-by-categories>
   </div>
 </template>

--- a/src/components/Panel.vue
+++ b/src/components/Panel.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { Tags, Font, FontTagGroup, GF, FontTag } from "../models";
+import { Tags, Font, FontTagGroup, GF } from "../models";
 import { defineProps, defineEmits, onMounted } from "vue";
 
 type FontPanel = {
@@ -18,18 +18,7 @@ const props = defineProps<{
   tags: Tags,
   gf: GF,
 }>();
-const emit = defineEmits(["remove-panel", 'remove-tag', 'add-font-panel', 'update:tags']);
-
-// Bubble emits to parent
-function removeTag(tag: FontTag) {
-  emit('remove-tag', tag);
-}
-function addFontPanel(font: string) {
-  emit('add-font-panel', font);
-}
-function updateTags(tags: Tags) {
-  emit('update:tags', tags);
-}
+const emit = defineEmits(["remove-panel"]);
 
 import { delegate } from 'tippy.js';
 import 'tippy.js/dist/tippy.css';
@@ -56,8 +45,7 @@ onMounted(() => {
 <template>
   <div class="panel" style="border:1px solid #ccc; padding:1em; margin-bottom:1em;">
     <button @click="emit('remove-panel')" style="float:right">✕</button>
-    <tags-by-font v-if="panel.type === 'font'" :tags="tags" :font="panel.font" :gf="gf" @remove-tag="removeTag"
-      @add-font-panel="addFontPanel" @update:tags="updateTags"></tags-by-font>
+    <tags-by-font v-if="panel.type === 'font'" :tags="tags" :font="panel.font" :gf="gf"></tags-by-font>
     <tags-by-categories v-else-if="panel.type === 'categories'" :tags="tags" :categories="panel.categories"
       :tagGroups="panel.tagGroups" :gf="gf" @remove-tag="removeTag"></tags-by-categories>
   </div>

--- a/src/components/Panel.vue
+++ b/src/components/Panel.vue
@@ -11,7 +11,10 @@ type CategoriesPanel = {
   categories: string[]; // Array of category names
   tagGroups: FontTagGroup[]; // Array of FontTagGroup objects
 };
-export type Panel = FontPanel | CategoriesPanel; // Union type for panel
+type TodoPanel = {
+  type: "todo"; // Type of panel
+};
+export type Panel = FontPanel | CategoriesPanel | TodoPanel; // Union type for panel
 
 const props = defineProps<{
   panel: Panel,
@@ -48,5 +51,6 @@ onMounted(() => {
     <tags-by-font v-if="panel.type === 'font'" :tags="tags.items" :font="panel.font" :gf="gf"></tags-by-font>
     <tags-by-categories v-else-if="panel.type === 'categories'" :tags="tags.items" :categories="panel.categories"
       :tagGroups="panel.tagGroups" :gf="gf"></tags-by-categories>
+    <todo v-else-if="panel.type === 'todo'" :gf="gf" :tags="tags"></todo>
   </div>
 </template>

--- a/src/components/Panel.vue
+++ b/src/components/Panel.vue
@@ -22,7 +22,7 @@ const emit = defineEmits(["remove-panel"]);
 
 import { delegate } from 'tippy.js';
 import 'tippy.js/dist/tippy.css';
-import 'tippy.js/themes/light-border.css';
+import 'tippy.js/themes/material.css';
 
 
 
@@ -36,7 +36,7 @@ onMounted(() => {
     allowHTML: true,
     placement: 'top',
     arrow: true,
-    theme: 'light-border',
+    theme: 'material',
     maxWidth: 300
   });
 });

--- a/src/components/TagView.vue
+++ b/src/components/TagView.vue
@@ -38,7 +38,7 @@ const removeTag = () => {
             </span>
             <button @click="removeTag" class="remove-tag-btn">Remove</button>
         </div>
-        <div class="text-editor" contenteditable="true" :style="props.tag?.cssStyle">
+        <div class="text-editor" contenteditable="true" :style="props.tag?.cssStyle(32)">
             Hello world
         </div>
     </div>

--- a/src/components/TagView.vue
+++ b/src/components/TagView.vue
@@ -27,7 +27,7 @@ const removeTag = () => {
     <div class="tag-view">
         <div class="tag-title">
             <span class="tag-name">{{ props.tag?.tagName }}
-                <svg xmlns="http://www.w3.org/2000/svg" height="22px" viewBox="http://www.w3.org/2000/svg" fill="#000000">
+                <svg xmlns="http://www.w3.org/2000/svg" height="22px" viewBox="0 -1000 960 960" fill="#000000">
                     <path d=" M440-280h80v-240h-80v240Zm40-320q17 0 28.5-11.5T520-640q0-17-11.5-28.5T480-680q-17 0-28.5
                     11.5T440-640q0 17 11.5 28.5T480-600Zm0 520q-83 0-156-31.5T197-197q-54-54-85.5-127T80-480q0-83
                     31.5-156T197-763q54-54 127-85.5T480-880q83 0 156 31.5T763-763q54 54 85.5 127T880-480q0 83-31.5

--- a/src/components/TagView.vue
+++ b/src/components/TagView.vue
@@ -1,10 +1,15 @@
 <script setup lang="ts">
-import { defineProps, onMounted, defineEmits } from 'vue';
-import { FontTag, GF } from '../models';
+import { defineProps, onBeforeMount } from 'vue';
+import { FontTag } from '../models';
+import { EventBus } from '@/eventbus';
 
 const props = defineProps({
     tag: FontTag,
-    gf: GF
+});
+
+
+onBeforeMount(() => {
+    EventBus.$emit('ensure-loaded', props.tag?.family.name);
 });
 
 const emit = defineEmits(['remove-tag']);
@@ -16,6 +21,7 @@ const removeTag = () => {
 }
 
 </script>
+
 
 <template>
     <div class="tag-view">

--- a/src/components/TagView.vue
+++ b/src/components/TagView.vue
@@ -12,11 +12,9 @@ onBeforeMount(() => {
     EventBus.$emit('ensure-loaded', props.tag?.family.name);
 });
 
-const emit = defineEmits(['remove-tag']);
-
 const removeTag = () => {
     if (props.tag) {
-        emit('remove-tag', props.tag);
+        EventBus.$emit('remove-tag', props.tag);
     }
 }
 

--- a/src/components/TagsByFont.vue
+++ b/src/components/TagsByFont.vue
@@ -58,13 +58,12 @@ const lintErrors = computed(() => {
   return props.gf.linter(props.gf.lintRules, font.value, filteredTags.value) || [];
 });
 
-// These are emitted to the panel component; remember to handle them there
 function removeTag(tag: FontTag) {
-  emit('remove-tag', tag);
+  EventBus.$emit('remove-tag', tag);
 }
 function addFontPanel(font: string) {
   console.log("Emitting add-font-panel from TagsByFont for ", font);
-  emit('add-font-panel', font);
+  EventBus.$emit('add-font-panel', font);
 }
 
 onBeforeMount(() => {
@@ -103,7 +102,7 @@ onBeforeMount(() => {
               d="M440-280h80v-240h-80v240Zm40-320q17 0 28.5-11.5T520-640q0-17-11.5-28.5T480-680q-17 0-28.5 11.5T440-640q0 17 11.5 28.5T480-600Zm0 520q-83 0-156-31.5T197-197q-54-54-85.5-127T80-480q0-83 31.5-156T197-763q54-54 127-85.5T480-880q83 0 156 31.5T763-763q54 54 85.5 127T880-480q0 83-31.5 156T763-197q-54 54-127 85.5T480-80Z" />
           </svg>
         </span>
-        <input type="number" v-model="tag.score" @change="emit('update:tags', tags)" />
+        <input type="number" v-model="tag.score" @change="EventBus.$emit('update:tags', tags)" />
         <button @click="removeTag(tag)">Remove</button>
       </li>
     </ul>

--- a/src/components/TagsByFont.vue
+++ b/src/components/TagsByFont.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
+import { EventBus } from '@/eventbus';
 import { FontTag, GF } from '@/models';
-import { computed, defineProps, getCurrentInstance, ref } from 'vue';
+import { computed, defineProps, onBeforeMount, ref } from 'vue';
 
 const props = defineProps({
   tags: {
@@ -65,6 +66,12 @@ function addFontPanel(font: string) {
   console.log("Emitting add-font-panel from TagsByFont for ", font);
   emit('add-font-panel', font);
 }
+
+onBeforeMount(() => {
+  // Ensure the font is included in the CSS
+  EventBus.$emit('ensure-loaded', font?.value);
+});
+
 </script>
 <template>
   <div>

--- a/src/components/TagsByFont.vue
+++ b/src/components/TagsByFont.vue
@@ -95,7 +95,7 @@ onBeforeMount(() => {
         <input type="range" v-model="axis.value" :min="axis.min" :max="axis.max" />
     </div>
     <ul>
-      <li v-for="tag in filteredTags" :key="tag.tagName + tag.family.name + tag.score">
+      <li v-for="tag in filteredTags" :key="tag.tagName + tag.family.name">
         <span class="tag-name">{{ tag.tagName }}
           <svg xmlns="http://www.w3.org/2000/svg" height="22px" viewBox="0 -1000 960 960" width="24px" fill="#000000"
             v-if="props.gf?.tagDefinitions[tag.tagName]">

--- a/src/components/TagsByFont.vue
+++ b/src/components/TagsByFont.vue
@@ -92,7 +92,7 @@ onBeforeUpdate(() => {
     <div contenteditable="true" :style="cssStyle" style="border: 1px solid #ccc; padding: 1em;">
       Grumpy wizards make toxic brew for the evil Queen and Jack.
     </div>
-    <div v-for="axis in selectedFamily.axes" :key="axis.tag">
+    <div v-for="axis in selectedFamily?.axes" :key="axis.tag">
       <label>{{ axis.tag }}: {{ axis.value }}</label>
       <input type="range" v-model="axis.value" :min="axis.min" :max="axis.max" />
     </div>

--- a/src/components/TagsByFont.vue
+++ b/src/components/TagsByFont.vue
@@ -68,7 +68,10 @@ function addFontPanel(font: string) {
 
 onBeforeMount(() => {
   // Ensure the font is included in the CSS
-  EventBus.$emit('ensure-loaded', font?.value);
+  EventBus.$emit('ensure-loaded', font?.value)
+  similarFamilies.value.forEach(family => {
+    props.gf?.ensureLoaded(family);
+  });
 });
 
 </script>

--- a/src/components/Todo.vue
+++ b/src/components/Todo.vue
@@ -152,7 +152,7 @@ const randomUntagged = computed(randomUntaggedRefreshable.getter);
                 <span>100</span>
             </div>
             <input type="number" v-model="newScore" placeholder="Score (0-100)">
-            <button @click="props.tags.addTag(randomUntagged.family.name, randomUntagged.tagname, [], newScore)">
+            <button @click="props.tags.addTag(randomUntagged.tagname, randomUntagged.family.name, [], newScore)">
                 Tag it!</button>
             </p>
 

--- a/src/components/Todo.vue
+++ b/src/components/Todo.vue
@@ -66,7 +66,7 @@ function getNextUntagged(): Untagged | null {
         // Grab a random tagname
         const tagname = tagnames[Math.floor(Math.random() * tagnames.length)];
         // If the family is not tagged with the tagname, return it
-        if (!props.tags.has(family.name, tagname)) {
+        if (!props.tags.has(tagname, family.name)) {
             EventBus.$emit('ensure-loaded', family.name);
             return {
                 family,

--- a/src/components/Todo.vue
+++ b/src/components/Todo.vue
@@ -1,0 +1,162 @@
+<script setup lang="ts">
+import { EventBus } from '@/eventbus';
+import { Font, GF, TagDefinition, Tags } from '@/models';
+import type { Exemplars } from '@/models';
+import { computed, defineProps, ref } from 'vue';
+
+interface Untagged {
+    family: Font;
+    tagname: string;
+    tag_definition: TagDefinition;
+    exemplars: Exemplars
+}
+
+const props = defineProps({
+    gf: {
+        type: GF,
+        required: true
+    },
+    tags: {
+        type: Tags,
+        required: true
+    }
+})
+
+const newScore = ref(0);
+
+function useRefreshable<T>(getter: () => T): {
+    getter(): T;
+    refresh(): void;
+} {
+    const refreshKey = ref(0);
+
+    return {
+        getter() {
+            refreshKey.value;
+            return getter();
+        },
+        refresh() {
+            refreshKey.value++;
+        },
+    };
+}
+
+const completeness = computed(() => {
+    const families = props.gf.families;
+    const uniqueTags = new Set<string>();
+    for (var definition of Object.keys(props.gf.tagDefinitions)) {
+        uniqueTags.add(definition);
+    }
+    for (var tag of props.tags.items) {
+        uniqueTags.add(tag.tagName);
+    }
+    const tagnames = Array.from(uniqueTags);
+    return (props.tags.items.length / (families.length * tagnames.length)) * 100;
+});
+
+function getNextUntagged(): Untagged | null {
+    const families = props.gf.families;
+    const tagnames = Object.keys(props.gf.tagDefinitions);
+    if (completeness.value >= 100) {
+        return null; // All fonts are tagged
+    }
+    while (true) {
+        // Grab a random family
+        const family = families[Math.floor(Math.random() * families.length)];
+        // Grab a random tagname
+        const tagname = tagnames[Math.floor(Math.random() * tagnames.length)];
+        // If the family is not tagged with the tagname, return it
+        if (!props.tags.has(family.name, tagname)) {
+            EventBus.$emit('ensure-loaded', family.name);
+            return {
+                family,
+                tagname: tagname,
+                tag_definition: props.gf.tagDefinitions[tagname],
+                exemplars: props.gf.tagDefinitions[tagname].exemplars(props.tags)
+            };
+        }
+    }
+}
+
+const randomUntaggedRefreshable = useRefreshable(getNextUntagged);
+const randomUntagged = computed(randomUntaggedRefreshable.getter);
+</script>
+
+<template>
+    <div id="todo-wrapper">
+        <div v-if="!randomUntagged">All fonts are tagged!</div>
+
+        <div v-else>
+            <div class="progressbar">
+                <div class="progress" :style="{ width: completeness + '%' }">
+                </div>
+                <div class="progress-text">
+                    Tagging is {{ completeness.toFixed(2) }}% complete...
+                </div>
+            </div>
+
+            <h1>Is
+                <span class="family" :style="{ fontFamily: randomUntagged.family.name }">{{ randomUntagged.family.name
+                }}</span>
+                &nbsp;<span class="tag-name">{{ randomUntagged.tagname
+                    }}</span>?
+            </h1>
+            <h3>({{ randomUntagged.tag_definition.superShortDescription }})</h3>
+
+            <div class="sample" contenteditable="true" :style="{ fontFamily: randomUntagged.family.name }"
+                style="border: 1px solid #ccc; padding: 1em;">
+                Grumpy wizards make toxic brew for the evil Queen and Jack.
+            </div>
+
+            <p v-html="randomUntagged.tag_definition.description"></p>
+
+            <div class="exemplars">
+                <div class="exemplars-low">
+                    <h3 v-if="randomUntagged.exemplars.low.length">Examples of <i>low</i> {{ randomUntagged.tagname
+                        }}</h3>
+                    <div v-for="tag in randomUntagged.exemplars.low" :key="tag.family.name + tag.tagName + tag.score">
+                        <compact-tag-view :tag="tag"></compact-tag-view>
+                    </div>
+                </div>
+                <div class="exemplars-medium">
+                    <h3 v-if="randomUntagged.exemplars.medium.length">Examples of <i>medium</i> {{
+                        randomUntagged.tagname
+                        }}</h3>
+                    <div v-for="tag in randomUntagged.exemplars.medium"
+                        :key="tag.family.name + tag.tagName + tag.score">
+                        <compact-tag-view :tag="tag"></compact-tag-view>
+                    </div>
+                </div>
+                <div class="exemplars-high">
+                    <h3 v-if="randomUntagged.exemplars.high.length">Examples of <i>high</i> {{ randomUntagged.tagname
+                        }}</h3>
+                    <div v-for="tag in randomUntagged.exemplars.high" :key="tag.family.name + tag.tagName + tag.score">
+                        <compact-tag-view :tag="tag"></compact-tag-view>
+                    </div>
+                </div>
+            </div>
+
+            <p>
+            <div class="rangeslider">
+                <input type="range" v-model="newScore" min="0" max="100" step="1" style="vertical-align: middle;">
+                <span>0</span>
+                <span>10</span>
+                <span>20</span>
+                <span>30</span>
+                <span>40</span>
+                <span>50</span>
+                <span>60</span>
+                <span>70</span>
+                <span>80</span>
+                <span>90</span>
+                <span>100</span>
+            </div>
+            <input type="number" v-model="newScore" placeholder="Score (0-100)">
+            <button @click="props.tags.addTag(randomUntagged.family.name, randomUntagged.tagname, [], newScore)">
+                Tag it!</button>
+            </p>
+
+            <button @click="randomUntaggedRefreshable.refresh">Give me another</button>
+        </div>
+    </div>
+</template>

--- a/src/eventbus.ts
+++ b/src/eventbus.ts
@@ -1,0 +1,2 @@
+import Vue from 'vue';
+export const EventBus = new Vue();

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,14 +1,15 @@
 import Vue from "vue";
 import App from "./App.vue";
-import Panel from "./components/Panel.vue";
+import "./assets/main.css";
+import AddCategory from "./components/AddCategory.vue";
 import AddTag from "./components/AddTag.vue";
 import AddTags from "./components/AddTags.vue";
-import AddCategory from "./components/AddCategory.vue";
+import CompactTagView from "./components/CompactTagView.vue";
+import Panel from "./components/Panel.vue";
 import TagView from "./components/TagView.vue";
 import TagsByCategories from "./components/TagsByCategories.vue";
 import TagsByFont from "./components/TagsByFont.vue";
-
-import "./assets/main.css";
+import Todo from "./components/Todo.vue";
 
 Vue.component("panel", Panel);
 Vue.component("add-tag", AddTag);
@@ -17,6 +18,8 @@ Vue.component("add-category", AddCategory);
 Vue.component("tags-by-categories", TagsByCategories);
 Vue.component("tags-by-font", TagsByFont);
 Vue.component("tag-view", TagView);
+Vue.component("compact-tag-view", CompactTagView);
+Vue.component("todo", Todo);
 
 var app = new Vue({
   el: "#app",

--- a/src/models.ts
+++ b/src/models.ts
@@ -300,8 +300,20 @@ export class Tags {
     return this.items.map((tag) => tag.toCSV()).join("\n");
   }
   addTag(tagName: string, fontName: string, axes: any[], score: number) {
-    const tag = new FontTag(tagName, fontName, axes, score);
+    let family = this.gf.family(fontName);
+    if (family === undefined || family.name === undefined) {
+      console.warn("Family not found (adding tag):", fontName);
+      return;
+    }
+    if (this.has(tagName, fontName)) {
+      console.warn(
+        `Tag ${tagName} for font ${fontName} already exists. Skipping addition.`
+      );
+      return;
+    }
+    const tag = new FontTag(tagName, family, axes, score);
     this.items.push(tag);
+
   }
   has(tagName: string, fontName: string): boolean {
     return this.items.some((tag) => {

--- a/src/models.ts
+++ b/src/models.ts
@@ -149,6 +149,7 @@ export class Font {
 export class GF {
   familyData: { [key: string]: any }; // Object to hold family metadata
   families: Font[]; // Array to hold Font objects
+  loadedFamilies: Font[]; // We add families to the CSS on demand to speed up loading
   tagDefinitions: { [key: string]: TagDefinition }; // Object to hold tag definitions
   lintRules: LintRule[]; // Array to hold lint rules
   linter: any; // Linter instance
@@ -159,6 +160,7 @@ export class GF {
     this.tagDefinitions = {};
     this.lintRules = [];
     this.linter = linter;
+    this.loadedFamilies = [];
   }
   async getFamilyData() {
     let data = await loadText("family_data.json");

--- a/src/models.ts
+++ b/src/models.ts
@@ -36,11 +36,11 @@ export class FontTag {
       .join(";");
     return `${this.tagName},${this.family.name},${locationCSV},${this.score}`;
   }
-  get cssStyle() {
+  cssStyle(fontSize = 32) {
     if (this.location.length === 0) {
-      return `font-family: ${this.family.name}; font-size: 32pt;`;
+      return `font-family: ${this.family.name}; font-size: ${fontSize}pt;`;
     }
-    let style = `font-family: "${this.family.name}", "Adobe NotDef"; font-size: 32pt; font-variation-settings:`;
+    let style = `font-family: "${this.family.name}", "Adobe NotDef"; font-size: ${fontSize}pt; font-variation-settings:`;
     for (let axis of this.location) {
       style += ` '${axis.tagName}' ${axis.value},`;
     }
@@ -98,11 +98,11 @@ export class Font {
   get isVF() {
     return this.axes.length > 0;
   }
-  get cssStyle() {
+  cssStyle(fontSize = 32) {
     if (!this.isVF) {
-      return `font-family: '${this.name}'; font-size: 32pt;`;
+      return `font-family: '${this.name}'; font-size: ${fontSize}pt;`;
     }
-    let res = `font-family: '${this.name}'; font-size: 32pt; font-variation-settings:`;
+    let res = `font-family: '${this.name}'; font-size: ${fontSize}pt; font-variation-settings:`;
     this.axes.forEach((axis) => {
       res += ` '${axis.tag}' ${axis.min}..${axis.max},`;
     });

--- a/src/models.ts
+++ b/src/models.ts
@@ -251,6 +251,13 @@ export class GF {
       .map((item) => item[0])
       .filter((familyName) => familyName !== name);
   }
+  ensureLoaded(family: string) {
+    // We could use a Set for this but Vue can't diff them
+    let font = this.families.find((f) => f.name === family);
+    if (font && !this.loadedFamilies.includes(font)) {
+      this.loadedFamilies.push(font);
+    }
+  }
 }
 
 export class Tags {

--- a/src/models.ts
+++ b/src/models.ts
@@ -303,6 +303,11 @@ export class Tags {
     const tag = new FontTag(tagName, fontName, axes, score);
     this.items.push(tag);
   }
+  has(tagName: string, fontName: string): boolean {
+    return this.items.some((tag) => {
+      return tag.tagName === tagName && tag.family.name === fontName;
+    });
+  }
   sort() {
     this.items.sort((a, b) => a.tagName.localeCompare(b.tagName));
   }

--- a/src/models.ts
+++ b/src/models.ts
@@ -13,6 +13,12 @@ export type Location = {
   tagName: string; // Name of the tag, e.g. 'Weight'
 };
 
+export type Exemplars = {
+  high: FontTag[];
+  low: FontTag[];
+  medium: FontTag[];
+};
+
 export class FontTag {
   tagName: string;
   family: Font;
@@ -76,13 +82,32 @@ export class TagDefinition {
     this.superShortDescription = superShortDescription;
     this.related = related;
   }
-  get exemplars() {
-    return this.related.map((tag) => {
-      return {
-        name: tag,
-        url: `https://fonts.google.com/specimen/${tag.replace(/ /g, "+")}`,
-      };
-    });
+  exemplars(tags: Tags): Exemplars {
+    const exemplars: Exemplars = {
+      high: [],
+      low: [],
+      medium: [],
+    };
+    for (const tag of tags.items) {
+      if (tag.tagName !== this.name) {
+        continue;
+      }
+      if (tag.score > 80) {
+        exemplars.high.push(tag);
+      } else if (tag.score <= 20) {
+        exemplars.low.push(tag);
+      } else if (exemplars.medium.length < 3) {
+        exemplars.medium.push(tag);
+      }
+    }
+    // Choose top three high
+    exemplars.high.sort((a, b) => b.score - a.score);
+    exemplars.high = exemplars.high.slice(0, 3);
+    // Choose lowest three low
+    exemplars.low.sort((a, b) => a.score - b.score);
+    exemplars.low = exemplars.low.slice(0, 3);
+    console.log(`Exemplars for ${this.name}:`, exemplars);
+    return exemplars;
   }
 }
 


### PR DESCRIPTION
@m4rc1e hopefully this does not clash with what you are working on. Makes loading more efficient as it only loads font CSS on demand instead of making 2000+ CSS files on load. :-)

- **Use a global event bus and load font CSS on demand to speed app loading**
- **Don't re-render tag when score changes, else we lose focus on keyboarding**
- **Since we have a global event bus, we don't need to propagate events any more**
- **Similar families should also be ensured before being rendered**
